### PR TITLE
models setup and DbContext

### DIFF
--- a/Models/cause.cs
+++ b/Models/cause.cs
@@ -1,0 +1,14 @@
+using System.ComponentModel.DataAnnotations;
+using System.Collections.Generic;
+
+namespace volunteerMatch.Models;
+
+public class Cause
+{
+    public int Id { get; set; }
+    public string Name { get; set; }
+    public string ImageUrl { get; set; }
+    public string Description { get; set; }
+
+    public ICollection<Organization> Organizations { get; set; }
+}

--- a/Models/organizationFollower.cs
+++ b/Models/organizationFollower.cs
@@ -1,0 +1,14 @@
+using System.ComponentModel.DataAnnotations;
+using System.Collections.Generic;
+
+namespace volunteerMatch.Models;
+
+// Models/OrganizationFollower.cs
+public class OrganizationFollower
+{
+    public int VolunteerId { get; set; }
+    public Volunteer Volunteer { get; set; }
+
+    public int OrganizationId { get; set; }
+    public Organization Organization { get; set; }
+}

--- a/Models/organizations.cs
+++ b/Models/organizations.cs
@@ -1,0 +1,21 @@
+using System.ComponentModel.DataAnnotations;
+using System.Collections.Generic;
+
+namespace volunteerMatch.Models;
+
+// Models/Organization.cs
+public class Organization
+{
+    public int Id { get; set; }
+    public int VolunteerId { get; set; }
+    public string Name { get; set; }
+    public string ImageURL { get; set; }
+    public string Description { get; set; }
+    public string Location { get; set; }
+    public int CauseId { get; set; }
+    public bool IsFollowing { get; set; }
+
+    public Volunteer Volunteer { get; set; }
+    public Cause Cause { get; set; }
+    public ICollection<OrganizationFollower> OrganizationFollowers { get; set; }
+}

--- a/Models/volunteer.cs
+++ b/Models/volunteer.cs
@@ -1,0 +1,17 @@
+using System.ComponentModel.DataAnnotations;
+using System.Collections.Generic;
+
+namespace volunteerMatch.Models;
+
+// Models/Volunteer.cs
+public class Volunteer
+{
+    public int Id { get; set; }
+    public string Uid { get; set; }
+    public string FirstName { get; set; }
+    public string LastName { get; set; }
+    public string Email { get; set; }
+    public string ImageUrl { get; set; }
+
+    public ICollection<OrganizationFollower> OrganizationFollowers { get; set; }
+}

--- a/volunteer-match-API.sln
+++ b/volunteer-match-API.sln
@@ -1,0 +1,24 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.2.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VolunteerMatch", "VolunteerMatch.csproj", "{5A5975D4-1DF5-A77D-FB7A-C3196398AF21}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{5A5975D4-1DF5-A77D-FB7A-C3196398AF21}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5A5975D4-1DF5-A77D-FB7A-C3196398AF21}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5A5975D4-1DF5-A77D-FB7A-C3196398AF21}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5A5975D4-1DF5-A77D-FB7A-C3196398AF21}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {9A8F271F-0F4E-4C3D-93EE-338CC8AA67AA}
+	EndGlobalSection
+EndGlobal

--- a/volunteerMatchDbContext.cs
+++ b/volunteerMatchDbContext.cs
@@ -1,0 +1,78 @@
+// Data/VolunteerMatchDbContext.cs
+using Microsoft.EntityFrameworkCore;
+using volunteerMatch.Models;
+
+
+public class VolunteerMatchDbContext : DbContext
+    {
+        public VolunteerMatchDbContext(DbContextOptions<VolunteerMatchDbContext> options) : base(options) { }
+
+        public DbSet<Volunteer> Volunteers { get; set; }
+        public DbSet<Organization> Organizations { get; set; }
+        public DbSet<Cause> Causes { get; set; }
+        public DbSet<OrganizationFollower> OrganizationFollowers { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+
+            // Composite key for join table
+            modelBuilder.Entity<OrganizationFollower>()
+                .HasKey(of => new { of.VolunteerId, of.OrganizationId });
+
+            // Relationships
+            modelBuilder.Entity<OrganizationFollower>()
+                .HasOne(of => of.Volunteer)
+                .WithMany(v => v.OrganizationFollowers)
+                .HasForeignKey(of => of.VolunteerId);
+
+            modelBuilder.Entity<OrganizationFollower>()
+                .HasOne(of => of.Organization)
+                .WithMany(o => o.OrganizationFollowers)
+                .HasForeignKey(of => of.OrganizationId);
+
+            modelBuilder.Entity<Organization>()
+                .HasOne(o => o.Volunteer)
+                .WithMany() // You can replace this with a collection if needed
+                .HasForeignKey(o => o.VolunteerId);
+
+            modelBuilder.Entity<Organization>()
+                .HasOne(o => o.Cause)
+                .WithMany(c => c.Organizations)
+                .HasForeignKey(o => o.CauseId);
+
+            // Seed data
+            modelBuilder.Entity<Cause>().HasData(
+                new Cause { Id = 1, Name = "Environment", ImageUrl = "env.jpg", Description = "Protecting the planet" },
+                new Cause { Id = 2, Name = "Education", ImageUrl = "edu.jpg", Description = "Supporting learning" },
+                new Cause { Id = 3, Name = "Animals", ImageUrl = "animals.jpg", Description = "Helping pets and wildlife" }
+            );
+
+            modelBuilder.Entity<Volunteer>().HasData(
+                new Volunteer { Id = 1, Uid = "abc123", FirstName = "Alex", LastName = "Johnson", Email = "alex@example.com", ImageUrl = "alex.jpg" },
+                new Volunteer { Id = 2, Uid = "def456", FirstName = "Taylor", LastName = "Smith", Email = "taylor@example.com", ImageUrl = "taylor.jpg" }
+            );
+
+            modelBuilder.Entity<Organization>().HasData(
+                new Organization
+                {
+                    Id = 1,
+                    VolunteerId = 1,
+                    Name = "Save the Cats",
+                    ImageURL = "cats.jpg",
+                    Description = "Rescue and rehome cats",
+                    Location = "Nashville",
+                    CauseId = 3,
+                    IsFollowing = false
+                }
+            );
+
+            modelBuilder.Entity<OrganizationFollower>().HasData(
+                new OrganizationFollower
+                {
+                    VolunteerId = 2,
+                    OrganizationId = 1
+                }
+            );
+        }
+    }


### PR DESCRIPTION
## Add Volunteer, Organization, Cause, and OrganizationFollower models with DbContext setup and seed data

###  What's Included:
- Created model classes based on ERD:
  - `Volunteer`
  - `Organization`
  - `Cause`
  - `OrganizationFollower` (join table)
- Set up `VolunteerMatchDbContext`:
  - Registered all `DbSet` properties
  - Configured relationships and composite keys for many-to-many mapping
- Added seed data for:
  - 3 initial `Cause` records
  - 2 `Volunteer` users
  - 1 `Organization`
  - 1 `OrganizationFollower` entry

This commit lays the foundation for EF Core migrations and CRUD operations across all major entities in the VolunteerMatch platform.
