### PR TITLE
Changed GET Calls for Querying

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -100,21 +100,17 @@ using (var scope = app.Services.CreateScope())
 // =============================
 // VOLUNTEERS
 // =============================
-app.MapGet("/volunteers", async (HttpRequest request, VolunteerMatchDbContext db) =>
-{
-    var uid = request.Query["uid"].FirstOrDefault();
-
-    if (!string.IsNullOrEmpty(uid))
-    {
-        var match = await db.Volunteers.FirstOrDefaultAsync(v => v.Uid == uid);
-        return match is not null ? Results.Ok(match) : Results.NotFound();
-    }
-
-    return Results.Ok(await db.Volunteers.ToListAsync());
-});
+app.MapGet("/volunteers", async (VolunteerMatchDbContext db) =>
+    await db.Volunteers.ToListAsync());
 
 app.MapGet("/volunteers/{id}", async (int id, VolunteerMatchDbContext db) =>
     await db.Volunteers.FindAsync(id));
+
+app.MapGet("/volunteers/uid/{uid}", async (string uid, VolunteerMatchDbContext db) =>
+{
+    var match = await db.Volunteers.FirstOrDefaultAsync(v => v.Uid == uid);
+    return match is not null ? Results.Ok(match) : Results.NotFound();
+});
 
 app.MapPost("/volunteers", async (Volunteer volunteer, VolunteerMatchDbContext db) =>
 {


### PR DESCRIPTION
# Refactor: UID-Based Volunteer Lookup

## Summary

This PR updates how we handle fetching volunteers by `uid` in the Volunteer Match API. Previously, the `GET /volunteers` endpoint was used with an optional `uid` query parameter to filter for a specific volunteer. This approach led to inconsistent results and unnecessary data being returned.

We have now introduced a dedicated `GET /volunteers/uid/{uid}` endpoint for retrieving a single volunteer by Firebase UID, which results in a more RESTful and reliable API design.

---

## ✅ Changes Made

- Removed `uid` query logic from `GET /volunteers`
- Added new route: `GET /volunteers/uid/{uid}`
- All existing list, create, update, and delete logic for volunteers remains untouched